### PR TITLE
Move executable from lib/win to content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -289,3 +289,5 @@ __pycache__/
 build/Tools/NuGet/nuget.exe
 src/verpatch.exe
 src/verpatch-ReadMe.txt
+src/content/verpatch-ReadMe.txt
+src/content/verpatch.exe

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Publishing to Internal ProGet Server
-1. Download latest verpatch release from https://ddverpatch.codeplex.com/ (TODO: Update link if migrated to GitHub.)
-2. Extract [verpatch.exe, verpatch-ReadMe.txt] to src folder
+1. Download latest verpatch release from https://github.com/pavel-a/ddverpatch
+2. Extract [verpatch.exe, verpatch-ReadMe.txt] to src/content folder
 3. Run .\build Publish
 
 # Publishing to NuGet.org

--- a/src/content/.exe-goes-here
+++ b/src/content/.exe-goes-here
@@ -1,0 +1,1 @@
+This file is a place-holder to make sure the content folder is included in the repo. This is where any new version of verpatch.exe and readme.txt should go for updates.

--- a/src/verpatch.nuspec
+++ b/src/verpatch.nuspec
@@ -2,26 +2,26 @@
 <package xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <metadata>
     <id>verpatch</id>
-    <version>1.0.14</version>
+    <version>2.0.0</version>
     <title>Verpatch</title>
     <authors>ddbug</authors>
     <summary>Simple command line editor for executable file version and other properties.</summary>
     <description>Verpatch is a little tool that we made for building and maintenance of console applications, DLLs, kernel drivers and so on. 
 Besides updating version info or create a complete version resource, it can add binary resources to executable, remove debug information path.
-</description>
+    </description>
     <language>en-US</language>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <developmentDependency>true</developmentDependency>
     <releaseNotes>
     </releaseNotes>
-	<projectUrl>https://ddverpatch.codeplex.com/</projectUrl>
-	<licenseUrl>https://ddverpatch.codeplex.com/license</licenseUrl>
-    <copyright>Copyright ©  2017</copyright>
+	  <projectUrl>https://github.com/pavel-a/ddverpatch</projectUrl>
+	  <license type="file">readme.txt</license>
+    <copyright>Copyright ï¿½  2017</copyright>
     <frameworkAssemblies />
     <dependencies />   
   </metadata>
   <files>
-    <file src="verpatch.exe" target="lib\win" exclude="" />
-    <file src="verpatch-ReadMe.txt" target="lib\win" exclude="" />
+    <file src="content/verpatch-ReadMe.txt" target="readme.txt" />
+    <file src="content/verpatch.exe" target="content" />
   </files>
 </package>


### PR DESCRIPTION
This allows installing into any project. The README was updated to
reflect the new project URL and the correct destination for files from
new verpatch builds. The psake build system was not tested, but the
output from "nuget pack" is correct.

Issue #1